### PR TITLE
Count down container prop style

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Run `npm install react-native-countdown-component --save` OR `yarn add react-nat
 | Name | Description | Type | Default Value |
 | :--- | :----- | :--- | :---: |
 | style | Override the component style | object | {} |
+| countDownContainerStyle |  Count Down Style | object | {} |
 | digitStyle |  Digit style | object | {backgroundColor: ![#FAB913](https://placehold.it/15/FAB913/000000?text=+) `'#FAB913'`} |
 | digitTxtStyle | Digit Text style | object | {color: ![#FAB913](https://placehold.it/15/000000/000000?text=+) `'#000'`} |
 | timeLabelStyle | Time Label style | object | {color: ![#FAB913](https://placehold.it/15/000000/000000?text=+) `'#000'`} |

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const DEFAULT_TIME_LABELS = {
 
 class CountDown extends React.Component {
   static propTypes = {
+    countDownContainerStyle: PropTypes.object,
     digitStyle: PropTypes.object,
     digitTxtStyle: PropTypes.object,
     timeLabelStyle: PropTypes.object,
@@ -177,7 +178,7 @@ class CountDown extends React.Component {
   };
 
   renderCountDown = () => {
-    const {timeToShow, timeLabels, showSeparator} = this.props;
+    const {timeToShow, timeLabels, showSeparator, countDownContainerStyle} = this.props;
     const {until} = this.state;
     const {days, hours, minutes, seconds} = this.getTimeLeft();
     const newTime = sprintf('%02d:%02d:%02d:%02d', days, hours, minutes, seconds).split(':');
@@ -185,7 +186,7 @@ class CountDown extends React.Component {
 
     return (
       <Component
-        style={styles.timeCont}
+        style={{...styles.timeCont, ...countDownContainerStyle}}
         onPress={this.props.onPress}
       >
         {timeToShow.includes('D') ? this.renderDoubleDigits(timeLabels.d, newTime[0]) : null}
@@ -209,6 +210,7 @@ class CountDown extends React.Component {
 }
 
 CountDown.defaultProps = {
+  countDownContainerStyle: {},
   digitStyle: DEFAULT_DIGIT_STYLE,
   digitTxtStyle: DEFAULT_DIGIT_TXT_STYLE,
   timeLabelStyle: DEFAULT_TIME_LABEL_STYLE,


### PR DESCRIPTION
When RN App is RTL order of countdown section is reversed. like this (default styles):
![image](https://user-images.githubusercontent.com/9904514/53306886-00c3bd80-38a8-11e9-8d23-dc8ed82fe0ad.png)
with custom countdown prop style, the user can set `flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row'` to have the correct style. this is my problem also this props has better for any another customizing component.