### PR TITLE
feat: Add the remaining time to onChange()'s props

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ class CountDown extends React.Component {
         this.props.onFinish();
       }
       if (this.props.onChange) {
-        this.props.onChange();
+        this.props.onChange(until);
       }
     }
 
@@ -110,7 +110,7 @@ class CountDown extends React.Component {
       this.setState({lastUntil: 0, until: 0});
     } else {
       if (this.props.onChange) {
-        this.props.onChange();
+        this.props.onChange(until);
       }
       this.setState({lastUntil: until, until: until - 1});
     }


### PR DESCRIPTION
Add the remaining time to onChange()'s props and it can be used this way:
`onChange={(timeLeft) => console.log(timeLeft)}`
