### PR TITLE
Fix digit overflow on google pixel device

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class CountDown extends React.Component {
       <View style={[
         styles.digitCont,
         digitStyle,
-        {width: size * 2.3, height: size * 2.6},
+        {paddinghorizontal: 20, height: size * 2.6},
       ]}>
         <Text style={[
           styles.digitTxt,


### PR DESCRIPTION
Hello @talalmajali,

I've found a style bug and it's happen on some device. The digits are overflow and here is screenshot
![ss](https://user-images.githubusercontent.com/20050523/55129489-dcc6f680-5149-11e9-917c-d99d6abf4e4f.jpeg)

and this how I call this component
```
<CountDown
  digitBgColor='#F5928D'
  digitTxtColor='#FFFFFF'
  timeTxtColor='#F5928D'
  timeLabelStyle={{display:'none'}}
  until={diffTime}
  timeToShow={['H', 'M', 'S']}
  onFinish={this.failedTransfer}
  size={20}
  digitStyle={{padding:20}}
/>
```