### PR TITLE
[expo][web] Removed old syntax preventing non-cjs tree shaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,4 +260,5 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = CountDown;
+export default CountDown;
+export { CountDown };


### PR DESCRIPTION
Related: https://github.com/expo/expo/pull/4151