### PR TITLE
Option to display numbers without leading zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,19 @@ class CountDown extends React.Component {
     const {timeToShow, timeLabels, showSeparator} = this.props;
     const {until} = this.state;
     const {days, hours, minutes, seconds} = this.getTimeLeft();
-    const newTime = sprintf('%02d:%02d:%02d:%02d', days, hours, minutes, seconds).split(':');
+
+    const daysPlaceholder = timeToShow.includes('d') ? '%d' : '%02d';
+    const hoursPlaceholder = timeToShow.includes('h') ? '%d' : '%02d';
+    const minutesPlaceholder = timeToShow.includes('m') ? '%d' : '%02d';
+    const secondsPlaceholder = timeToShow.includes('s') ? '%d' : '%02d';
+
+    const newTime = sprintf(
+      daysPlaceholder + ':' +
+      hoursPlaceholder + ':' +
+      minutesPlaceholder + ':' +
+      secondsPlaceholder,
+      days, hours, minutes, seconds).split(':');
+
     const Component = this.props.onPress ? TouchableOpacity : View;
 
     return (
@@ -194,13 +206,13 @@ class CountDown extends React.Component {
         style={styles.timeCont}
         onPress={this.props.onPress}
       >
-        {timeToShow.includes('D') ? this.renderDoubleDigits(timeLabels.d, newTime[0]) : null}
-        {showSeparator && timeToShow.includes('D') && timeToShow.includes('H') ? this.renderSeparator() : null}
-        {timeToShow.includes('H') ? this.renderDoubleDigits(timeLabels.h, newTime[1]) : null}
-        {showSeparator && timeToShow.includes('H') && timeToShow.includes('M') ? this.renderSeparator() : null}
-        {timeToShow.includes('M') ? this.renderDoubleDigits(timeLabels.m, newTime[2]) : null}
-        {showSeparator && timeToShow.includes('M') && timeToShow.includes('S') ? this.renderSeparator() : null}
-        {timeToShow.includes('S') ? this.renderDoubleDigits(timeLabels.s, newTime[3]) : null}
+        {timeToShow.includes('D') || timeToShow.includes('d') ? this.renderDoubleDigits(timeLabels.d, newTime[0]) : null}
+        {showSeparator && (timeToShow.includes('D') || timeToShow.includes('d')) && (timeToShow.includes('H') || timeToShow.includes('h')) ? this.renderSeparator() : null}
+        {timeToShow.includes('H') || timeToShow.includes('h') ? this.renderDoubleDigits(timeLabels.h, newTime[1]) : null}
+        {showSeparator && (timeToShow.includes('H') || timeToShow.includes('h')) && (timeToShow.includes('M') || timeToShow.includes('m')) ? this.renderSeparator() : null}
+        {timeToShow.includes('M') || timeToShow.includes('m') ? this.renderDoubleDigits(timeLabels.m, newTime[2]) : null}
+        {showSeparator && (timeToShow.includes('M') || timeToShow.includes('m')) && (timeToShow.includes('S') || timeToShow.includes('s')) ? this.renderSeparator() : null}
+        {timeToShow.includes('S') || timeToShow.includes('s') ? this.renderDoubleDigits(timeLabels.s, newTime[3]) : null}
       </Component>
     );
   };


### PR DESCRIPTION
This pull request implements to option to display the countdown time values without a leading zero. By default, the `timeToShow` prop has an array of uppercase letters (`['D', 'H', 'M', 'S']`); with this pull request, these uppercase letters denote that a leading zero **will** be displayed. However, if lowercase counterparts of the same letters are used in `timeToShow`, the leading zero will be hidden. This is done through adjusting the `sprintf()` use case in the codebase such that when a lowercase character is being used, the placeholder parameter in the function is `%d` instead of `%02d`.