### PR TITLE
Round state until for stop in right time

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class CountDown extends React.Component {
   _handleAppStateChange = currentAppState => {
     const {until, wentBackgroundAt} = this.state;
     if (currentAppState === 'active' && wentBackgroundAt && this.props.running) {
-      const diff = (Date.now() - wentBackgroundAt) / 1000.0;
+      const diff = Math.round((Date.now() - wentBackgroundAt) / 1000.0);
       this.setState({
         lastUntil: until,
         until: Math.max(0, until - diff)


### PR DESCRIPTION
When you get the time that the app stay in background, the state until goes to float, so when the time end, the countdown need for more one second to stop, so we need round it.