### PR TITLE
Fix update until prop for 2.7.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,22 +59,15 @@ class CountDown extends React.Component {
     AppState.removeEventListener('change', this._handleAppStateChange);
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.props.until !== prevProps.until || this.props.id !== prevProps.id) {
+  shouldComponentUpdate(nextProps) {
+    if (this.props.until !== nextProps.until || this.props.id !== nextProps.id) {
       this.setState({
-        lastUntil: prevState.until,
-        until: Math.max(prevProps.until, 0)
+        lastUntil: this.state.until,
+        until: Math.max(nextProps.until, 0)
       });
     }
+    return true
   }
-  // componentWillReceiveProps(nextProps) {
-  //   if (this.props.until !== nextProps.until || this.props.id !== nextProps.id) {
-  //     this.setState({
-  //       lastUntil: this.state.until,
-  //       until: Math.max(nextProps.until, 0)
-  //     });
-  //   }
-  // }
 
   _handleAppStateChange = currentAppState => {
     const {until, wentBackgroundAt} = this.state;


### PR DESCRIPTION
Fix issue #74 after pr #48 for removing deprecated `componentWillReceiveProps`

I use `react-native` version `0.61.5` and got same issue #74 after updating `react-native-countdown-component` to `2.7.1`