### PR TITLE
AppState.removeEventListener deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,12 @@ class CountDown extends React.Component {
   }
 
   componentDidMount() {
-    AppState.addEventListener('change', this._handleAppStateChange);
+    this.eventListener = AppState.addEventListener('change', this._handleAppStateChange);
   }
 
   componentWillUnmount() {
     clearInterval(this.timer);
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    this.eventListener.remove;
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class CountDown extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer);
-    this.eventListener.remove;
+    this.eventListener.remove();
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
Saving the component event listener created on mount to remove on unmount.