### PR TITLE
FIX (Android) : TypeError: _reactNative.AppState.removeEventListener

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class CountDown extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer);
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    // AppState.removeEventListener('change', this._handleAppStateChange);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
TypeError: _reactNative.AppState.removeEventListener is not a function (it is undefined).